### PR TITLE
Improve README and requirements: Clarify SciPy _lazywhere ImportError and Link Related Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,6 @@ Code examples of the free course in Youtube of [brain MRI preprocessing techniqu
 
 ## Setup Instructions
 
-### Know issue with SciPy
-If you encounter the following error:
-
-```python
-ImportError: cannot import name '_lazywhere' from 'scipy._lib._util'
-```
-
-This occurs because the `_lazywhere` function was removed in SciPy v1.16.0.
-
-To resolve this, ensure that SciPy is pinned to **version ≤ 1.15.0**. This has already been addressed in both `requirements.txt` and the `Dockerfile`.
-For more details, see the related discussions in the [statsmodels GitHub issues](https://github.com/statsmodels/statsmodels/issues):
-
-- [Issue #9542](https://github.com/statsmodels/statsmodels/issues/9542): ImportError with `_lazywhere` in SciPy 1.16.0
-- [Issue #9584](https://github.com/statsmodels/statsmodels/issues/9584): Compatibility problems with newer SciPy versions
-
-
 ### Using venv (for Linux only)
 ```
 python -m venv .venv
@@ -55,6 +39,24 @@ NVIDIA GeForce MX130 2GB dedicated RAM
 8GB Ram
 ```
 From my experience, the project should run normally in a pc with a processor of 2 cores(or more) and 8gb RAM(or more).
+
+
+### Known issue with SciPy
+If you encounter the following error:
+
+```python
+ImportError: cannot import name '_lazywhere' from 'scipy._lib._util'
+```
+
+This occurs because the `_lazywhere` function was removed in SciPy v1.16.0.
+
+To resolve this, ensure that SciPy is pinned to **version ≤ 1.15.0**. This has already been addressed in both `requirements.txt` and the `Dockerfile`.
+For more details, see the related discussions in the [statsmodels GitHub issues](https://github.com/statsmodels/statsmodels/issues):
+
+- [Issue #9542](https://github.com/statsmodels/statsmodels/issues/9542): ImportError with `_lazywhere` in SciPy 1.16.0
+- [Issue #9584](https://github.com/statsmodels/statsmodels/issues/9584): Compatibility problems with newer SciPy versions
+
+
 
 ## About `/assets`
 I selected sample images and templates from the following sources

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 Code examples of the free course in Youtube of [brain MRI preprocessing techniques in python](https://www.youtube.com/playlist?list=PLI3eIHxETjX4a5NMmgayg3wuM232fYIxy)
 
 ## Setup Instructions
+
+### Know issue with SciPy
+If you encounter the following error:
+
+```python
+ImportError: cannot import name '_lazywhere' from 'scipy._lib._util'
+```
+
+This occurs because the `_lazywhere` function was removed in SciPy v1.16.0.
+
+To resolve this, ensure that SciPy is pinned to **version ≤ 1.15.0**. This has already been addressed in both `requirements.txt` and the `Dockerfile`.
+For more details, see the related discussions in the [statsmodels GitHub issues](https://github.com/statsmodels/statsmodels/issues):
+
+- [Issue #9542](https://github.com/statsmodels/statsmodels/issues/9542): ImportError with `_lazywhere` in SciPy 1.16.0
+- [Issue #9584](https://github.com/statsmodels/statsmodels/issues/9584): Compatibility problems with newer SciPy versions
+
+
 ### Using venv (for Linux only)
 ```
 python -m venv .venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ notebook
 SimpleITK==2.4.0
 antspyx==0.5.4
 antspynet
+scipy==1.15.0


### PR DESCRIPTION
This PR enhances the `README.md` to clarify the known compatibility issue with _SciPy ≥ 1.16.0_, specifically in regards to the removal of the `_lazywhere` function that causes import errors.

**Changes made:**

- Reformatted the error explanation for clarity.
- Linked to related statsmodels GitHub issues ([#9542](https://github.com/statsmodels/statsmodels/issues/9542), [#9584](https://github.com/statsmodels/statsmodels/issues/9584)) for further context.

The course and codes have been an amazing learning resource. I've been going over them now and, with these changes, was able to get them to work perfectly. Thank you for your contribution to the community.